### PR TITLE
Idea: Use validation context only when needed

### DIFF
--- a/lib/servi.rb
+++ b/lib/servi.rb
@@ -22,7 +22,11 @@ class Servi
   end
 
   def commit
-    form = self.class.const_get(:Input).new(input, self.validation_context)
+    form = self.class.const_get(:Input).new(input)
+
+    if form.respond_to?(:context)
+      form.context(self.validation_context)
+    end
 
     if form.valid?
       build(form.attributes)
@@ -68,10 +72,9 @@ class Servi
     end
   end
 
-  class Input < ::Scrivener
-    def initialize(atts, context)
+  module InputWithValidationContext
+    def context(context)
       @context = context
-      super(atts)
     end
   end
 

--- a/test/servi_test.rb
+++ b/test/servi_test.rb
@@ -38,7 +38,7 @@ class Post::Create < Servi
     success(post: post)
   end
 
-  class Input < Servi::Input
+  class Input < Scrivener
     attr_accessor :title
     attr_accessor :content
 
@@ -125,7 +125,9 @@ class Comment::Delete < Servi
     { user: user }
   end
 
-  class Input < Servi::Input
+  class Input < Scrivener
+    include Servi::InputWithValidationContext
+
     attr_accessor :comment
 
     def validate


### PR DESCRIPTION
In this way, you may still use your Scrivener classes.
